### PR TITLE
fix: use self instead of window or document for worker context

### DIFF
--- a/frontend/packages/common-frontend/src/ConnectionIndicator.ts
+++ b/frontend/packages/common-frontend/src/ConnectionIndicator.ts
@@ -454,10 +454,10 @@ export class ConnectionIndicator extends LitElement {
 
   private timeoutFor(timeoutId: number, enabled: boolean, handler: () => void, delay: number): number {
     if (timeoutId !== 0) {
-      self.window.clearTimeout(timeoutId);
+      self.clearTimeout(timeoutId);
     }
 
-    return enabled ? self.window.setTimeout(handler, delay) : 0;
+    return enabled ? self.setTimeout(handler, delay) : 0;
   }
 
   static get instance(): ConnectionIndicator {

--- a/frontend/packages/common-frontend/src/ConnectionIndicator.ts
+++ b/frontend/packages/common-frontend/src/ConnectionIndicator.ts
@@ -41,7 +41,7 @@ export class ConnectionIndicator extends LitElement {
    * window.Vaadin.connectionIndicator and add instance to the document body.
    */
   static create(): ConnectionIndicator {
-    const $wnd = window as any;
+    const $wnd = self as any;
     if (!$wnd.Vaadin?.connectionIndicator) {
       $wnd.Vaadin ??= {};
       $wnd.Vaadin.connectionIndicator = document.createElement('vaadin-connection-indicator');
@@ -454,10 +454,10 @@ export class ConnectionIndicator extends LitElement {
 
   private timeoutFor(timeoutId: number, enabled: boolean, handler: () => void, delay: number): number {
     if (timeoutId !== 0) {
-      window.clearTimeout(timeoutId);
+      self.window.clearTimeout(timeoutId);
     }
 
-    return enabled ? window.setTimeout(handler, delay) : 0;
+    return enabled ? self.window.setTimeout(handler, delay) : 0;
   }
 
   static get instance(): ConnectionIndicator {

--- a/frontend/packages/common-frontend/src/ConnectionState.ts
+++ b/frontend/packages/common-frontend/src/ConnectionState.ts
@@ -140,10 +140,10 @@ export const isLocalhost = (hostname: string) => {
   return false;
 };
 
-const $wnd = window as any;
+const $wnd = self as any;
 if (!$wnd.Vaadin?.connectionState) {
   let online;
-  if (isLocalhost(window.location.hostname)) {
+  if (isLocalhost(self.window.location.hostname)) {
     // We do not know if we are online or not as we cannot trust navigator.onLine which checks availability of a network connection. Better to assume online so localhost apps can work
     online = true;
   } else {

--- a/frontend/packages/common-frontend/src/ConnectionState.ts
+++ b/frontend/packages/common-frontend/src/ConnectionState.ts
@@ -143,7 +143,8 @@ export const isLocalhost = (hostname: string) => {
 const $wnd = self as any;
 if (!$wnd.Vaadin?.connectionState) {
   let online;
-  if (isLocalhost(self.window.location.hostname)) {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (self.location && isLocalhost(self.location.hostname)) {
     // We do not know if we are online or not as we cannot trust navigator.onLine which checks availability of a network connection. Better to assume online so localhost apps can work
     online = true;
   } else {

--- a/frontend/packages/common-frontend/src/index.ts
+++ b/frontend/packages/common-frontend/src/index.ts
@@ -1,7 +1,7 @@
 export * from './ConnectionState.js';
 export * from './ConnectionIndicator.js';
 
-const $wnd = window as any;
+const $wnd = self as any;
 $wnd.Vaadin ??= {};
 $wnd.Vaadin.registrations ??= [];
 // eslint-disable-next-line @typescript-eslint/no-unsafe-call


### PR DESCRIPTION
Adjust the library to be used in the Service Worker context without DOM global variables

Fixes https://github.com/vaadin/hilla/issues/2867

