### PR TITLE
build: Replace deprecated image runner

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   testing:
     name: Test & Analysis
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
       NX_SKIP_NX_CACHE: true


### PR DESCRIPTION
The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025. To raise awareness of the upcoming removal, we will temporarily fail jobs using Ubuntu 20.04. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:


March 4 14:00 UTC – 22:00 UTC
March 11 13:00 UTC – 21:00 UTC
March 18 13:00 UTC – 21:00 UTC
March 25 13:00 UTC – 21:00 UTC
What you need to do

Jobs using the ubuntu-20.04 YAML workflow label should be updated to ubuntu-22.04, ubuntu-24.04 or ubuntu-latest.