### PR TITLE
fix: display connection indicator as native popover

### DIFF
--- a/packages/ts/common-frontend/src/ConnectionIndicator.ts
+++ b/packages/ts/common-frontend/src/ConnectionIndicator.ts
@@ -14,7 +14,7 @@
  * the License.
  */
 
-import { html, LitElement } from 'lit';
+import { html, LitElement, type PropertyValues } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { ConnectionState, type ConnectionStateStore } from './ConnectionState.js';
@@ -193,6 +193,12 @@ export class ConnectionIndicator extends LitElement {
     this.#isPopover = false;
   }
 
+  protected override updated(props: PropertyValues): void {
+    if (['loading', 'offline', 'reconnecting', 'expanded'].some((p) => props.has(p))) {
+      this.#updatePopoverState();
+    }
+  }
+
   get applyDefaultTheme() {
     return this.#applyDefaultThemeState;
   }
@@ -213,9 +219,10 @@ export class ConnectionIndicator extends LitElement {
     // Allow showing the indicator as popover
     this.setAttribute('popover', 'manual');
     // Override user agent styles for popover
+    this.style.display = 'contents';
     this.style.border = 'none';
-    this.style.padding = '0';
     this.style.background = 'none';
+    this.style.padding = '0';
     this.style.width = '0';
     this.style.height = '0';
     this.style.overflow = 'visible';
@@ -232,7 +239,6 @@ export class ConnectionIndicator extends LitElement {
     this.offline = connectionState === ConnectionState.CONNECTION_LOST;
     this.reconnecting = connectionState === ConnectionState.RECONNECTING;
     this.#updateLoading(connectionState === ConnectionState.LOADING);
-    this.#updatePopoverState();
     if (this.loading) {
       // Entering loading state, do not show message
       return false;
@@ -281,7 +287,7 @@ export class ConnectionIndicator extends LitElement {
   }
 
   #updatePopoverState() {
-    const showPopover = this.loading || this.offline || this.reconnecting;
+    const showPopover = this.loading || this.offline || this.reconnecting || this.expanded;
 
     if (showPopover && !this.#isPopover) {
       this.showPopover();

--- a/packages/ts/common-frontend/src/ConnectionIndicator.ts
+++ b/packages/ts/common-frontend/src/ConnectionIndicator.ts
@@ -118,6 +118,9 @@ export class ConnectionIndicator extends LitElement {
   @state()
   accessor #loadingBarState: LoadingBarState = LoadingBarState.IDLE;
 
+  @state()
+  accessor #isPopover: boolean = false;
+
   #applyDefaultThemeState = true;
 
   #firstTimeout = 0;
@@ -167,6 +170,8 @@ export class ConnectionIndicator extends LitElement {
   override connectedCallback() {
     super.connectedCallback();
 
+    this.#initPopover();
+
     const $wnd = window as any;
     if ($wnd.Vaadin?.connectionState) {
       this.#connectionStateStore = $wnd.Vaadin.connectionState as ConnectionStateStore;
@@ -185,6 +190,7 @@ export class ConnectionIndicator extends LitElement {
     }
 
     this.#updateTheme();
+    this.#isPopover = false;
   }
 
   get applyDefaultTheme() {
@@ -203,6 +209,18 @@ export class ConnectionIndicator extends LitElement {
     return this;
   }
 
+  #initPopover() {
+    // Allow showing the indicator as popover
+    this.setAttribute('popover', 'manual');
+    // Override user agent styles for popover
+    this.style.border = 'none';
+    this.style.padding = '0';
+    this.style.background = 'none';
+    this.style.width = '0';
+    this.style.height = '0';
+    this.style.overflow = 'visible';
+  }
+
   /**
    * Update state flags.
    *
@@ -214,6 +232,7 @@ export class ConnectionIndicator extends LitElement {
     this.offline = connectionState === ConnectionState.CONNECTION_LOST;
     this.reconnecting = connectionState === ConnectionState.RECONNECTING;
     this.#updateLoading(connectionState === ConnectionState.LOADING);
+    this.#updatePopoverState();
     if (this.loading) {
       // Entering loading state, do not show message
       return false;
@@ -260,6 +279,18 @@ export class ConnectionIndicator extends LitElement {
       this.thirdDelay,
     );
   }
+
+  #updatePopoverState() {
+    const showPopover = this.loading || this.offline || this.reconnecting;
+
+    if (showPopover && !this.#isPopover) {
+      this.showPopover();
+    } else if (!showPopover && this.#isPopover) {
+      this.hidePopover();
+    }
+    this.#isPopover = showPopover;
+  }
+
 
   #renderMessage() {
     if (this.reconnecting) {

--- a/packages/ts/common-frontend/src/ConnectionIndicator.ts
+++ b/packages/ts/common-frontend/src/ConnectionIndicator.ts
@@ -219,12 +219,6 @@ export class ConnectionIndicator extends LitElement {
     this.setAttribute('popover', 'manual');
     // Override user agent styles for popover
     this.style.display = 'contents';
-    this.style.border = 'none';
-    this.style.background = 'none';
-    this.style.padding = '0';
-    this.style.width = '0';
-    this.style.height = '0';
-    this.style.overflow = 'visible';
   }
 
   /**

--- a/packages/ts/common-frontend/src/ConnectionIndicator.ts
+++ b/packages/ts/common-frontend/src/ConnectionIndicator.ts
@@ -374,7 +374,6 @@ export class ConnectionIndicator extends LitElement {
       .v-loading-indicator,
       .v-status-message {
         position: fixed;
-        z-index: 251;
         left: 0;
         right: auto;
         top: 0;

--- a/packages/ts/common-frontend/src/ConnectionIndicator.ts
+++ b/packages/ts/common-frontend/src/ConnectionIndicator.ts
@@ -291,7 +291,6 @@ export class ConnectionIndicator extends LitElement {
     this.#isPopover = showPopover;
   }
 
-
   #renderMessage() {
     if (this.reconnecting) {
       return this.reconnectingText;

--- a/packages/ts/common-frontend/src/ConnectionIndicator.ts
+++ b/packages/ts/common-frontend/src/ConnectionIndicator.ts
@@ -118,7 +118,6 @@ export class ConnectionIndicator extends LitElement {
   @state()
   accessor #loadingBarState: LoadingBarState = LoadingBarState.IDLE;
 
-  @state()
   accessor #isPopover: boolean = false;
 
   #applyDefaultThemeState = true;

--- a/packages/ts/common-frontend/src/ConnectionIndicator.ts
+++ b/packages/ts/common-frontend/src/ConnectionIndicator.ts
@@ -288,10 +288,14 @@ export class ConnectionIndicator extends LitElement {
   #updatePopoverState() {
     const showPopover = this.loading || this.offline || this.reconnecting || this.expanded;
 
-    if (showPopover && !this.#isPopover) {
-      this.showPopover();
-    } else if (!showPopover && this.#isPopover) {
+    // Always close the popover first on state changes. This way, on every state change,
+    // showPopover is called again, resulting in the connection indicator being shown on
+    // top of other popovers that might have been added, for example after a reconnect.
+    if (this.#isPopover) {
       this.hidePopover();
+    }
+    if (showPopover) {
+      this.showPopover();
     }
     this.#isPopover = showPopover;
   }

--- a/packages/ts/common-frontend/test/ConnectionIndicator.test.ts
+++ b/packages/ts/common-frontend/test/ConnectionIndicator.test.ts
@@ -83,9 +83,10 @@ describe('ConnectionIndicator', () => {
     });
 
     it('should set popover styles when connected', () => {
+      assert.equal(connectionIndicator.style.display, 'contents');
       assert.equal(connectionIndicator.style.border, 'none');
-      assert.equal(connectionIndicator.style.padding, '0px');
       assert.equal(connectionIndicator.style.background, 'none');
+      assert.equal(connectionIndicator.style.padding, '0px');
       assert.equal(connectionIndicator.style.width, '0px');
       assert.equal(connectionIndicator.style.height, '0px');
       assert.equal(connectionIndicator.style.overflow, 'visible');
@@ -197,6 +198,7 @@ describe('ConnectionIndicator', () => {
       assert.equal(String(message.textContent).trim(), connectionIndicator.reconnectingText);
       // Message did change, should cause expanded
       assert.isTrue(connectionIndicator.hasAttribute('expanded'));
+      assert.isTrue(isPopoverOpen());
       await sleep(20);
       assert.isFalse(connectionIndicator.hasAttribute('expanded'));
       assert.isTrue(isPopoverOpen());
@@ -209,6 +211,7 @@ describe('ConnectionIndicator', () => {
       assert.equal(String(message.textContent).trim(), connectionIndicator.offlineText);
       // Message did change, should cause expanded
       assert.isTrue(connectionIndicator.hasAttribute('expanded'));
+      assert.isTrue(isPopoverOpen());
       await sleep(20);
       assert.isFalse(connectionIndicator.hasAttribute('expanded'));
       assert.isTrue(isPopoverOpen());
@@ -231,6 +234,7 @@ describe('ConnectionIndicator', () => {
       assert.equal(String(message.textContent).trim(), connectionIndicator.onlineText);
       // Message did change from before loading, should cause expanded
       assert.isTrue(connectionIndicator.hasAttribute('expanded'));
+      assert.isTrue(isPopoverOpen());
       await sleep(20);
       assert.isFalse(connectionIndicator.hasAttribute('expanded'));
       assert.isFalse(isPopoverOpen());

--- a/packages/ts/common-frontend/test/ConnectionIndicator.test.ts
+++ b/packages/ts/common-frontend/test/ConnectionIndicator.test.ts
@@ -77,20 +77,24 @@ describe('ConnectionIndicator', () => {
       // Add back to prevent errors in afterEach
       document.body.prepend(connectionIndicator);
     });
+
+    it('should set popover attribute when connected', () => {
+      assert.equal(connectionIndicator.getAttribute('popover'), 'manual');
+    });
+
+    it('should set popover styles when connected', () => {
+      assert.equal(connectionIndicator.style.border, 'none');
+      assert.equal(connectionIndicator.style.padding, '0px');
+      assert.equal(connectionIndicator.style.background, 'none');
+      assert.equal(connectionIndicator.style.width, '0px');
+      assert.equal(connectionIndicator.style.height, '0px');
+      assert.equal(connectionIndicator.style.overflow, 'visible');
+    });
   });
 
   describe('with state store', () => {
     let connectionStateStore: ConnectionStateStore;
     let message: HTMLSpanElement;
-
-    beforeEach(() => {
-      connectionStateStore = new ConnectionStateStore(ConnectionState.CONNECTED);
-      $wnd.Vaadin = { connectionState: connectionStateStore };
-    });
-
-    afterEach(() => {
-      delete $wnd.Vaadin;
-    });
 
     async function setupIndicator() {
       connectionIndicator = document.createElement('vaadin-connection-indicator');
@@ -100,137 +104,136 @@ describe('ConnectionIndicator', () => {
       message = connectionIndicator.querySelector('.v-status-message > span')!;
     }
 
-    function destroyIndicator() {
-      document.body.removeChild(connectionIndicator);
+    function isPopoverOpen() {
+      return document.querySelector('vaadin-connection-indicator:popover-open') !== null;
     }
 
-    it('initial state: connected', async () => {
-      try {
-        await setupIndicator();
+    beforeEach(() => {
+      connectionStateStore = new ConnectionStateStore(ConnectionState.CONNECTED);
+      $wnd.Vaadin = { connectionState: connectionStateStore };
+    });
 
-        assert.isFalse(connectionIndicator.hasAttribute('offline'));
-        assert.isFalse(connectionIndicator.hasAttribute('reconnecting'));
-        assert.isFalse(connectionIndicator.hasAttribute('loading'));
-        assert.isFalse(connectionIndicator.hasAttribute('expanded'));
-        assert.equal(String(message.textContent).trim(), connectionIndicator.onlineText);
-      } finally {
-        destroyIndicator();
-      }
+    afterEach(() => {
+      delete $wnd.Vaadin;
+      connectionIndicator.remove();
+    });
+
+    it('initial state: connected', async () => {
+      await setupIndicator();
+
+      assert.isFalse(connectionIndicator.hasAttribute('offline'));
+      assert.isFalse(connectionIndicator.hasAttribute('reconnecting'));
+      assert.isFalse(connectionIndicator.hasAttribute('loading'));
+      assert.isFalse(connectionIndicator.hasAttribute('expanded'));
+      assert.equal(String(message.textContent).trim(), connectionIndicator.onlineText);
     });
 
     it('initial state: loading', async () => {
-      try {
-        connectionStateStore.state = ConnectionState.LOADING;
-        await setupIndicator();
+      connectionStateStore.state = ConnectionState.LOADING;
+      await setupIndicator();
 
-        assert.isFalse(connectionIndicator.hasAttribute('offline'));
-        assert.isFalse(connectionIndicator.hasAttribute('reconnecting'));
-        assert.isTrue(connectionIndicator.hasAttribute('loading'));
-        assert.isFalse(connectionIndicator.hasAttribute('expanded'));
-        assert.equal(String(message.textContent).trim(), connectionIndicator.onlineText);
-      } finally {
-        destroyIndicator();
-      }
+      assert.isFalse(connectionIndicator.hasAttribute('offline'));
+      assert.isFalse(connectionIndicator.hasAttribute('reconnecting'));
+      assert.isTrue(connectionIndicator.hasAttribute('loading'));
+      assert.isFalse(connectionIndicator.hasAttribute('expanded'));
+      assert.equal(String(message.textContent).trim(), connectionIndicator.onlineText);
+      assert.isTrue(isPopoverOpen());
     });
 
     it('initial state: reconnecting', async () => {
-      try {
-        connectionStateStore.state = ConnectionState.RECONNECTING;
+      connectionStateStore.state = ConnectionState.RECONNECTING;
 
-        await setupIndicator();
+      await setupIndicator();
 
-        assert.isFalse(connectionIndicator.hasAttribute('offline'));
-        assert.isTrue(connectionIndicator.hasAttribute('reconnecting'));
-        assert.isFalse(connectionIndicator.hasAttribute('loading'));
-        assert.isFalse(connectionIndicator.hasAttribute('expanded'));
-        assert.equal(String(message.textContent).trim(), connectionIndicator.reconnectingText);
-      } finally {
-        destroyIndicator();
-      }
+      assert.isFalse(connectionIndicator.hasAttribute('offline'));
+      assert.isTrue(connectionIndicator.hasAttribute('reconnecting'));
+      assert.isFalse(connectionIndicator.hasAttribute('loading'));
+      assert.isFalse(connectionIndicator.hasAttribute('expanded'));
+      assert.equal(String(message.textContent).trim(), connectionIndicator.reconnectingText);
+      assert.isTrue(isPopoverOpen());
     });
 
     it('initial state: connection lost', async () => {
-      try {
-        connectionStateStore.state = ConnectionState.CONNECTION_LOST;
+      connectionStateStore.state = ConnectionState.CONNECTION_LOST;
 
-        await setupIndicator();
+      await setupIndicator();
 
-        assert.isTrue(connectionIndicator.hasAttribute('offline'));
-        assert.isFalse(connectionIndicator.hasAttribute('reconnecting'));
-        assert.isFalse(connectionIndicator.hasAttribute('loading'));
-        assert.isFalse(connectionIndicator.hasAttribute('expanded'));
-        assert.equal(String(message.textContent).trim(), connectionIndicator.offlineText);
-      } finally {
-        destroyIndicator();
-      }
+      assert.isTrue(connectionIndicator.hasAttribute('offline'));
+      assert.isFalse(connectionIndicator.hasAttribute('reconnecting'));
+      assert.isFalse(connectionIndicator.hasAttribute('loading'));
+      assert.isFalse(connectionIndicator.hasAttribute('expanded'));
+      assert.equal(String(message.textContent).trim(), connectionIndicator.offlineText);
+      assert.isTrue(isPopoverOpen());
     });
 
     it('should react on store state change', async () => {
-      try {
-        await setupIndicator();
+      await setupIndicator();
 
-        connectionStateStore.state = ConnectionState.LOADING;
-        await connectionIndicator.updateComplete;
-        assert.isFalse(connectionIndicator.hasAttribute('offline'));
-        assert.isFalse(connectionIndicator.hasAttribute('reconnecting'));
-        assert.equal(String(message.textContent).trim(), connectionIndicator.onlineText);
-        assert.isTrue(connectionIndicator.hasAttribute('loading'));
-        // Loading should not cause expanded message
-        assert.isFalse(connectionIndicator.hasAttribute('expanded'));
+      connectionStateStore.state = ConnectionState.LOADING;
+      await connectionIndicator.updateComplete;
+      assert.isFalse(connectionIndicator.hasAttribute('offline'));
+      assert.isFalse(connectionIndicator.hasAttribute('reconnecting'));
+      assert.equal(String(message.textContent).trim(), connectionIndicator.onlineText);
+      assert.isTrue(connectionIndicator.hasAttribute('loading'));
+      // Loading should not cause expanded message
+      assert.isFalse(connectionIndicator.hasAttribute('expanded'));
+      assert.isTrue(isPopoverOpen());
 
-        connectionStateStore.state = ConnectionState.CONNECTED;
-        await connectionIndicator.updateComplete;
-        assert.isFalse(connectionIndicator.hasAttribute('offline'));
-        assert.isFalse(connectionIndicator.hasAttribute('reconnecting'));
-        assert.isFalse(connectionIndicator.hasAttribute('loading'));
-        assert.equal(String(message.textContent).trim(), connectionIndicator.onlineText);
-        // Message did not change from before loading, should not cause expanded
-        assert.isFalse(connectionIndicator.hasAttribute('expanded'));
+      connectionStateStore.state = ConnectionState.CONNECTED;
+      await connectionIndicator.updateComplete;
+      assert.isFalse(connectionIndicator.hasAttribute('offline'));
+      assert.isFalse(connectionIndicator.hasAttribute('reconnecting'));
+      assert.isFalse(connectionIndicator.hasAttribute('loading'));
+      assert.equal(String(message.textContent).trim(), connectionIndicator.onlineText);
+      // Message did not change from before loading, should not cause expanded
+      assert.isFalse(connectionIndicator.hasAttribute('expanded'));
+      assert.isFalse(isPopoverOpen());
 
-        connectionStateStore.state = ConnectionState.RECONNECTING;
-        await connectionIndicator.updateComplete;
-        assert.isFalse(connectionIndicator.hasAttribute('offline'));
-        assert.isTrue(connectionIndicator.hasAttribute('reconnecting'));
-        assert.isFalse(connectionIndicator.hasAttribute('loading'));
-        assert.equal(String(message.textContent).trim(), connectionIndicator.reconnectingText);
-        // Message did change, should cause expanded
-        assert.isTrue(connectionIndicator.hasAttribute('expanded'));
-        await sleep(20);
-        assert.isFalse(connectionIndicator.hasAttribute('expanded'));
+      connectionStateStore.state = ConnectionState.RECONNECTING;
+      await connectionIndicator.updateComplete;
+      assert.isFalse(connectionIndicator.hasAttribute('offline'));
+      assert.isTrue(connectionIndicator.hasAttribute('reconnecting'));
+      assert.isFalse(connectionIndicator.hasAttribute('loading'));
+      assert.equal(String(message.textContent).trim(), connectionIndicator.reconnectingText);
+      // Message did change, should cause expanded
+      assert.isTrue(connectionIndicator.hasAttribute('expanded'));
+      await sleep(20);
+      assert.isFalse(connectionIndicator.hasAttribute('expanded'));
+      assert.isTrue(isPopoverOpen());
 
-        connectionStateStore.state = ConnectionState.CONNECTION_LOST;
-        await connectionIndicator.updateComplete;
-        assert.isTrue(connectionIndicator.hasAttribute('offline'));
-        assert.isFalse(connectionIndicator.hasAttribute('reconnecting'));
-        assert.isFalse(connectionIndicator.hasAttribute('loading'));
-        assert.equal(String(message.textContent).trim(), connectionIndicator.offlineText);
-        // Message did change, should cause expanded
-        assert.isTrue(connectionIndicator.hasAttribute('expanded'));
-        await sleep(20);
-        assert.isFalse(connectionIndicator.hasAttribute('expanded'));
+      connectionStateStore.state = ConnectionState.CONNECTION_LOST;
+      await connectionIndicator.updateComplete;
+      assert.isTrue(connectionIndicator.hasAttribute('offline'));
+      assert.isFalse(connectionIndicator.hasAttribute('reconnecting'));
+      assert.isFalse(connectionIndicator.hasAttribute('loading'));
+      assert.equal(String(message.textContent).trim(), connectionIndicator.offlineText);
+      // Message did change, should cause expanded
+      assert.isTrue(connectionIndicator.hasAttribute('expanded'));
+      await sleep(20);
+      assert.isFalse(connectionIndicator.hasAttribute('expanded'));
+      assert.isTrue(isPopoverOpen());
 
-        connectionStateStore.state = ConnectionState.LOADING;
-        await connectionIndicator.updateComplete;
-        assert.isFalse(connectionIndicator.hasAttribute('offline'));
-        assert.isFalse(connectionIndicator.hasAttribute('reconnecting'));
-        assert.equal(String(message.textContent).trim(), connectionIndicator.onlineText);
-        assert.isTrue(connectionIndicator.hasAttribute('loading'));
-        // Loading should not cause expanded message
-        assert.isFalse(connectionIndicator.hasAttribute('expanded'));
+      connectionStateStore.state = ConnectionState.LOADING;
+      await connectionIndicator.updateComplete;
+      assert.isFalse(connectionIndicator.hasAttribute('offline'));
+      assert.isFalse(connectionIndicator.hasAttribute('reconnecting'));
+      assert.equal(String(message.textContent).trim(), connectionIndicator.onlineText);
+      assert.isTrue(connectionIndicator.hasAttribute('loading'));
+      // Loading should not cause expanded message
+      assert.isFalse(connectionIndicator.hasAttribute('expanded'));
+      assert.isTrue(isPopoverOpen());
 
-        connectionStateStore.state = ConnectionState.CONNECTED;
-        await connectionIndicator.updateComplete;
-        assert.isFalse(connectionIndicator.hasAttribute('offline'));
-        assert.isFalse(connectionIndicator.hasAttribute('reconnecting'));
-        assert.isFalse(connectionIndicator.hasAttribute('loading'));
-        assert.equal(String(message.textContent).trim(), connectionIndicator.onlineText);
-        // Message did change from before loading, should cause expanded
-        assert.isTrue(connectionIndicator.hasAttribute('expanded'));
-        await sleep(20);
-        assert.isFalse(connectionIndicator.hasAttribute('expanded'));
-      } finally {
-        destroyIndicator();
-      }
+      connectionStateStore.state = ConnectionState.CONNECTED;
+      await connectionIndicator.updateComplete;
+      assert.isFalse(connectionIndicator.hasAttribute('offline'));
+      assert.isFalse(connectionIndicator.hasAttribute('reconnecting'));
+      assert.isFalse(connectionIndicator.hasAttribute('loading'));
+      assert.equal(String(message.textContent).trim(), connectionIndicator.onlineText);
+      // Message did change from before loading, should cause expanded
+      assert.isTrue(connectionIndicator.hasAttribute('expanded'));
+      await sleep(20);
+      assert.isFalse(connectionIndicator.hasAttribute('expanded'));
+      assert.isFalse(isPopoverOpen());
     });
 
     it('should not react on store state change after removed from DOM', async () => {
@@ -284,24 +287,28 @@ describe('ConnectionIndicator', () => {
       assert.isFalse(loadingBar.classList.contains('first'));
       assert.isFalse(loadingBar.classList.contains('second'));
       assert.isFalse(loadingBar.classList.contains('third'));
+      assert.isTrue(isPopoverOpen());
 
       await sleep(150);
       assert.isTrue(loadingBar.classList.contains('first'));
       assert.isFalse(loadingBar.classList.contains('second'));
       assert.isFalse(loadingBar.classList.contains('third'));
       assert.equal(loadingBar.getAttribute('style'), 'display: block');
+      assert.isTrue(isPopoverOpen());
 
       await sleep(150);
       assert.isFalse(loadingBar.classList.contains('first'));
       assert.isTrue(loadingBar.classList.contains('second'));
       assert.isFalse(loadingBar.classList.contains('third'));
       assert.equal(loadingBar.getAttribute('style'), 'display: block');
+      assert.isTrue(isPopoverOpen());
 
       await sleep(150);
       assert.isFalse(loadingBar.classList.contains('first'));
       assert.isFalse(loadingBar.classList.contains('second'));
       assert.isTrue(loadingBar.classList.contains('third'));
       assert.equal(loadingBar.getAttribute('style'), 'display: block');
+      assert.isTrue(isPopoverOpen());
 
       connectionStateStore.state = ConnectionState.CONNECTED;
       await connectionIndicator.updateComplete;
@@ -309,6 +316,7 @@ describe('ConnectionIndicator', () => {
       assert.isFalse(loadingBar.classList.contains('second'));
       assert.isFalse(loadingBar.classList.contains('third'));
       assert.equal(loadingBar.getAttribute('style'), 'display: none');
+      assert.isFalse(isPopoverOpen());
     });
   });
 });


### PR DESCRIPTION
## Description

In Vaadin 25, all overlay components (e.g. dialogs) are displayed as native popovers which puts them into the [top layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer). This layer is always shown on top of everything else, regardless what `z-index` an element might have. As such, the Vaadin connector indicator is now shown below a dialog and it's modality curtain.

This changes the connector indicator to be displayed as a native popover as well, which makes it appear on top of other popovers.

This change can not be applied in V24 due to lack of browser support.

Fixes https://github.com/vaadin/flow/issues/23173

## Type of change

- Bugfix
